### PR TITLE
Forwarding redesign adoption, consumer dependency docs, and CI concurrency

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -11,6 +11,12 @@ on:
     branches:
       - main
 
+# Superseded runs of the same ref waste the shared build machine, so cancel them for pull
+# requests. Push and tag runs on main are never cancelled mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   base-stage:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,9 @@ set(ROBOT_FARM_LIST_SEPARATOR "|")
     composes it (CMAKE_PREFIX_PATH gains the install prefix so children resolve packages
     installed by their siblings). Everything the user hands this configure (raw -D
     definitions, a preset's cacheVariables, a toolchain file) is forwarded by the helper
-    automatically and needs no listing here. ]]
+    automatically and needs no listing here, except names in this super build's own
+    ROBOT_FARM_ namespace: those are its interface, consumed at this level, and are excluded
+    from forwarding. ]]
 set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)
 set(CMAKE_EXPORT_PACKAGE_REGISTRY OFF)
 set(CMAKE_FIND_USE_PACKAGE_REGISTRY OFF)
@@ -59,6 +61,7 @@ compose_forwarded_cache_args(
   OUTPUT_VARIABLE ROBOT_FARM_FORWARDED_CMAKE_ARGS
   LIST_SEPARATOR ${ROBOT_FARM_LIST_SEPARATOR}
   USER_ENTRIES ${ROBOT_FARM_USER_CACHE_ENTRIES}
+  EXCLUDE_PREFIXES ROBOT_FARM_
   FORWARD_VARIABLES
     BUILD_SHARED_LIBS
     BUILD_TESTING

--- a/README.md
+++ b/README.md
@@ -413,6 +413,25 @@ The allowed values are:
 - SuiteSparseExternalProject
 - VTKExternalProject
 
+### Declaring your project's robotFarm system packages
+
+A consumer project owns the complete list of system packages it needs, including the packages
+required to build its robotFarm subset; nothing is read from robotFarm's generated files when a
+consumer builds its images. To derive a `RobotFarmDependencies` group for your project's
+`systemDependencies.json`:
+
+1. Expand your requested build list to its transitive closure. Each recipe in
+   [`externalProjects/`](externalProjects) `include()`s the recipes it depends on, so follow
+   those includes; for example, `Eigen3ExternalProject` pulls in `SuiteSparseExternalProject`.
+2. Union the groups named after each project in the closure from robotFarm's own
+   [`systemDependencies.json`](systemDependencies.json). A project without a group needs no
+   system packages and contributes nothing.
+
+robotFarm's `systemDependencies.json` serves robotFarm itself and doubles as the reference for
+this derivation. The `systemDependencies.txt` that a configure emits is the same computation
+performed for the configured build list, so it makes a convenient cross-check for a
+hand-derived group.
+
 ## 🧑‍💻 Developer notes
 
 ### Python 3


### PR DESCRIPTION
Follow-ups to #57, batched so the matrix spends one CI cycle.

- Bump infraCommons to the type-based cache-provenance redesign and pass EXCLUDE_PREFIXES ROBOT_FARM_ at the compose call: names in the super build's own namespace are its interface, consumed at its level, and no longer forwarded to children (this also silences the unused-variable warnings in child configures).
- Document how a consumer derives its RobotFarmDependencies group: expand the requested build list through the externalProjects include graph, union the matching groups from robotFarm's systemDependencies.json, with the emitted systemDependencies.txt as a cross-check.
- Add a concurrency group that cancels superseded pull-request runs so the shared build machine stops paying for dead work; push and tag runs are never cancelled.

Validated locally with CMake 4.4.2 against the gnu-static preset: children receive -DCMAKE_INSTALL_PREFIX:PATH=/opt/robotFarm and no ROBOT_FARM_-prefixed noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSXae9Ux4G6CVGmr57QAkZ