### PR TITLE
Pin Ceres to 2.2.0 and build on infraCommons weekly-base images

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -25,11 +25,11 @@ jobs:
       matrix:
         os_base:
           - name: ubuntu:22.04
-            image: ghcr.io/ajakhotia/infracommons/weekly/ubuntu:22.04
+            image: ghcr.io/ajakhotia/infracommons/weekly-base/ubuntu-22-04:latest
           - name: ubuntu:24.04
-            image: ghcr.io/ajakhotia/infracommons/weekly/ubuntu:24.04
+            image: ghcr.io/ajakhotia/infracommons/weekly-base/ubuntu-24-04:latest
           - name: ubuntu:26.04
-            image: ghcr.io/ajakhotia/infracommons/weekly/ubuntu:26.04
+            image: ghcr.io/ajakhotia/infracommons/weekly-base/ubuntu-26-04:latest
 
     steps:
       - name: self-checkout

--- a/docker/ubuntu.dockerfile
+++ b/docker/ubuntu.dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-ARG OS_BASE=ubuntu:22.04
+ARG OS_BASE=ghcr.io/ajakhotia/infracommons/weekly-base/ubuntu-24-04:latest
 
 FROM ${OS_BASE} AS base
 
@@ -16,47 +16,14 @@ ENV PATH=/usr/local/cuda/bin:${PATH}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN printf '%s\n'                                                                                  \
-    'path-exclude /usr/share/doc/*'                                                                \
-    'path-exclude /usr/share/man/*'                                                                \
-    'path-include /usr/share/locale/locale.alias'                                                  \
-    'path-include /usr/share/locale/en*/*'                                                         \
-    'path-exclude /usr/share/locale/*'                                                             \
-    'path-exclude /usr/share/info/*'                                                               \
-    > /etc/dpkg/dpkg.cfg.d/01_nodoc
-
-RUN printf '%s\n'                                                                                  \
-    'Acquire::http::Pipeline-Depth 0;'                                                             \
-    'Acquire::https::Pipeline-Depth 0;'                                                            \
-    'Acquire::http::No-Cache true;'                                                                \
-    'Acquire::https::No-Cache true;'                                                               \
-    'Acquire::BrokenProxy    true;'                                                                \
-    >> /etc/apt/apt.conf.d/90fix-hashsum-mismatch
-
-# Make apt resilient to flaky upstreams (e.g., Launchpad PPA hosting under stress):
-# 5 retries with short per-request timeouts so each failed attempt fails fast and
-# we get more shots at reaching a healthy backend behind the load balancer.
-RUN printf '%s\n'                                                                                  \
-    'Acquire::Retries "5";'                                                                        \
-    'Acquire::http::Timeout "30";'                                                                 \
-    'Acquire::https::Timeout "30";'                                                                \
-    > /etc/apt/apt.conf.d/91retry-and-timeouts
-
-RUN --mount=type=cache,target=/var/cache/apt,id=${APT_VAR_CACHE_ID},sharing=locked                 \
-    --mount=type=cache,target=/var/lib/apt/lists,id=${APT_LIST_CACHE_ID},sharing=locked            \
-    apt-get update &&                                                                              \
-    apt-get full-upgrade -y --no-install-recommends &&                                             \
-    apt-get autoremove -y --no-install-recommends &&                                               \
-    apt-get autoclean -y --no-install-recommends
-
+# The base image already ships the vendor apt sources and the bootstrap package set. jq is the
+# one extra tool needed here because extractDependencies.sh uses it to read
+# systemDependencies.json.
 RUN --mount=type=cache,target=/var/cache/apt,id=${APT_VAR_CACHE_ID},sharing=locked                  \
     --mount=type=cache,target=/var/lib/apt/lists,id=${APT_LIST_CACHE_ID},sharing=locked             \
     apt-get update &&                                                                               \
     apt-get install -y --no-install-recommends                                                      \
-      ca-certificates curl gnupg jq software-properties-common
-
-RUN --mount=type=bind,src=external/infraCommons/tools/apt/addAptSources.sh,dst=/tmp/tools/apt/addAptSources.sh,ro       \
-    bash /tmp/tools/apt/addAptSources.sh -y
+      jq
 
 RUN --mount=type=cache,target=/var/cache/apt,id=${APT_VAR_CACHE_ID},sharing=locked                                      \
     --mount=type=cache,target=/var/lib/apt/lists,id=${APT_LIST_CACHE_ID},sharing=locked                                 \

--- a/externalProjects/CeresSolverExternalProject.cmake
+++ b/externalProjects/CeresSolverExternalProject.cmake
@@ -35,6 +35,7 @@ else()
 
   externalproject_add(CeresSolverExternalProject
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ceressolver
+    GIT_TAG 2.2.0
     GIT_REPOSITORY ${ROBOT_FARM_CERES_SOLVER_URL}
     GIT_SHALLOW TRUE
     DOWNLOAD_NO_PROGRESS ON


### PR DESCRIPTION
Two follow-ups from the README audit and the consistency sweep, batched so the matrix runs once.

- CeresSolverExternalProject cloned the upstream default branch with no GIT_TAG, so builds were not reproducible over time. It now pins 2.2.0 in the same style as the other recipes.
- The docker base stage moves onto the infraCommons weekly-base images, which already carry the dpkg trimming, apt hardening, upgrade, bootstrap packages, and all vendor apt sources. The recipe sheds those layers and keeps jq as the one extra tool. The CI matrix follows, matching the shape nioc and units already landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSXae9Ux4G6CVGmr57QAkZ